### PR TITLE
Server side rendering of math equations (KaTeX)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ General idea is to stay off of enshittifying trend: no icons, less whitespace, l
 ## Features
 
 - Auto light and dark themes
-- Fast without bullshit - minified, minimal vanilla css, images are lazy-loaded, system fonts, no CDNs, functional without js if Katex is not used
+- Fast without bullshit - minified, minimal vanilla css, images are lazy-loaded, system fonts, no CDNs, functional without js
+- Server side rendering of mathematical and chemical equations (using KaTeX)
 - Site-wide search (can be disabled)
 - Keyboard-friendly: `h` to home, `t` to tags, `i` to search, `Tab` to navigate posts and search
 - Dynamic wiki-style table of contents
-- Katex math (inline and block)
+- KaTeX math (inline and block)
 - Info boxes
 - Attachments
 - Info boxes
@@ -23,7 +24,3 @@ General idea is to stay off of enshittifying trend: no icons, less whitespace, l
 
 [Example site, overview of features and configuration.](https://hugo-dead-simple.netlify.app/post/hugo-dead-simple/) \
 [Example site repo.](https://github.com/barklan/hugo-dead-simple-example)
-
-## TODO
-
-- https://gohugo.io/content-management/mathematics/ (recent hugo)

--- a/layouts/_default/_markup/render-passthrough.html
+++ b/layouts/_default/_markup/render-passthrough.html
@@ -1,0 +1,9 @@
+{{- $opts := dict "output" "htmlAndMathml" "displayMode" (eq .Type "block") }}
+{{- with try (transform.ToMath .Inner $opts) }}
+  {{- with .Err }}
+    {{ errorf "Unable to render mathematical markup to HTML using the transform.ToMath function. The KaTeX display engine threw the following error: %s: see %s." . $.Position }}
+  {{- else }}
+    {{- .Value }}
+    {{- $.Page.Store.Set "hasMath" true }}
+  {{- end }}
+{{- end -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -37,7 +37,4 @@
     {{ end }}
 {{ end }}
 
-{{ if .Params.math }}
-    {{ partial "math.html" . }}
-{{ end }}
 {{ partial "footer.html" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -60,6 +60,22 @@
         (resources.Get "css/misc.css")
     | resources.Concat "style.css" | minify | fingerprint }}
     <link rel="stylesheet" type="text/css" href="{{ $CSS.RelPermalink }}" media="all">
+
+    {{ $noop := .WordCount }}
+    {{ if .Page.Store.Get "hasMath" }}
+      {{ $katex_css_url := printf "https://cdn.jsdelivr.net/npm/katex@latest/dist/katex%s.css" (cond hugo.IsProduction ".min" "") -}}
+      {{ with try (resources.GetRemote $katex_css_url) -}}
+        {{ with .Err -}}
+          {{ errorf "Could not retrieve KaTeX css file from CDN. Reason: %s." . -}}
+        {{ else with.Value -}}
+          {{ with resources.Copy (printf "css/katex%s.css" (cond hugo.IsProduction ".min" "")) . }}
+            {{ $secureCSS := . | resources.Fingerprint "sha512" -}}
+<link rel="stylesheet" href="{{- .RelPermalink -}}" integrity="{{- $secureCSS.Data.Integrity -}}" crossorigin="anonymous">
+          {{ end -}}
+        {{ end -}}
+      {{ end -}}
+    {{ end }}
+
   </head>
 
   <body>

--- a/layouts/partials/math.html
+++ b/layouts/partials/math.html
@@ -1,3 +1,0 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.8/katex.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.8/katex.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.8/contrib/auto-render.min.js" crossorigin="anonymous" referrerpolicy="no-referrer" onload="renderMathInElement(document.body);"></script>

--- a/theme.toml
+++ b/theme.toml
@@ -21,7 +21,7 @@ features = [
   "table-of-contents",
   "favicon"
 ]
-min_version = "0.83.0"
+min_version = "0.141.0"
 
 [author]
     name = "Gleb Buzin"


### PR DESCRIPTION
This PR brings server side rendering of math equations via hugo's built-in KaTeX rendering engine.

**Advantages:**
- no JS needed for math content
- typesetting of formulae using LaTeX standard syntax, no escaping of delimiters needed
- use of `\\` as linebreak in block equations
- no need to activate math mode in frontmatter any more
- server side rendering (instead of client side rendering)
- internal rendering engine supports rendering of chemical equations out of the box (as of hugo version 0.144.0)
- no need to update KaTeX dependencies any more

**Disadvantages:**
- minimum required hugo version is now 0.141.0

This PR corresponds to this [PR]() in the repo of the hugo dead simple example site.

I hope you like this PR.